### PR TITLE
Fix payment amount

### DIFF
--- a/includes/paypro/edd/gateway/abstract.php
+++ b/includes/paypro/edd/gateway/abstract.php
@@ -45,7 +45,7 @@ abstract class PayPro_EDD_Gateway_Abstract
 			$callbackUrl = get_site_url() . '/?edd-listener=PAYPRO&payment-id=' . $eddPaymentID;
 
 			$payment = PayPro_EDD_Plugin::$paypro_api->createPayment([
-				'amount' => round($payment['price'], 2) * 100,
+				'amount' => (int) (round($payment['price'] * 100, 0)),
 				'pay_method' => $this->getPayMethod(),
 				'return_url' => $redirectUrl,
 				'cancel_url' => $redirectUrl,

--- a/includes/paypro/edd/plugin.php
+++ b/includes/paypro/edd/plugin.php
@@ -4,7 +4,7 @@ class PayPro_EDD_Plugin
 {
     const PLUGIN_ID = 'paypro-gateways-edd';
     const PLUGIN_TITLE = 'PayPro Gateways - Easy Digitial Downloads';
-    const PLUGIN_VERSION = '1.0.3';
+    const PLUGIN_VERSION = '1.0.4';
 
     public static $paypro_api;
     public static $settings;

--- a/paypro-gateways-edd.php
+++ b/paypro-gateways-edd.php
@@ -4,7 +4,7 @@
  * Plugin Name: PayPro Gateways - Easy Digital Downloads
  * Plugin URI: https://www.paypro.nl/
  * Description: With this plugin you easily add all PayPro payment gateways to your Easy Digital Downloads webshop.
- * Version: 1.0.3
+ * Version: 1.0.4
  * Author: PayPro
  * Author URI: https://www.paypro.nl/
  * Text Domain: paypro-gateways-edd


### PR DESCRIPTION
We receive the error: `amount 1998.9999999999998 is not a valid integer`, the amount is not rounded correctly.

Same issues we have:
https://github.com/paypronl/prestashop-payments-plugin/pull/2
https://github.com/paypronl/magento2-payments-plugin/pull/5