### PR TITLE
adding settings link

### DIFF
--- a/paypro-gateways-edd.php
+++ b/paypro-gateways-edd.php
@@ -28,6 +28,7 @@ function paypro_plugin_init()
     {
         PayPro_EDD_Autoload::register();
         PayPro_EDD_Plugin::init();
+        add_filter('plugin_action_links_' . plugin_basename(__FILE__), 'paypro_plugin_wc_action_links');
     }
 }
 
@@ -40,6 +41,16 @@ function edd_listen_for_paypro_notification()
     if (isset($_GET['edd-listener']) && $_GET['edd-listener'] === 'PAYPRO') {
         do_action('edd_paypro_notification');
     }
+}
+
+/**
+ * Add action links to paypro plugin 
+ */
+function paypro_plugin_wc_action_links($links) {
+    $paypro_links = array(
+        '<a href="'.admin_url('edit.php?post_type=download&page=edd-settings&tab=gateways&section=paypro').'"> Settings </a>'
+        );
+    return array_merge($paypro_links, $links);
 }
 
 /**


### PR DESCRIPTION
Added a settings links if easy-digital-download is activated so its easier to go to the settings once activated

if edd is activated:
![image](https://user-images.githubusercontent.com/55430516/146573552-e4e90123-fee3-4d20-b2bc-9c8ae242a9d7.png)

if edd is not active:
![image](https://user-images.githubusercontent.com/55430516/146573636-ac82dbad-dc5c-4e83-bad5-1f8a3a67076b.png)

